### PR TITLE
Set host origin to default

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,7 +11,7 @@ use Mix.Config
 # before starting your production server.
 config :midimatches, MidimatchesWeb.Endpoint,
   url: [
-    host: "midimatches.com",
+    host: nil,
     port: 80
   ],
   cache_static_manifest: "priv/static/cache_manifest.json"


### PR DESCRIPTION
- Set host to nil so that both midimatches.com and
midimatches.onrender.com resolve properly for all protocols