### PR TITLE
Use Cookie for MIDI Input Devices + Mute Ability via Cookies

### DIFF
--- a/assets/js/constants/constants.tsx
+++ b/assets/js/constants/constants.tsx
@@ -170,3 +170,4 @@ export const DEFAULT_ALERT_LIFETIME = 5_000;
 export const SOUND_VOLUME_COOKIE = "midimatches_soundvolume";
 export const SHOW_KEYBOARD_LABELS_COOKIE = "midimatches_keyboardlabels";
 export const SEEN_BROWSER_WARNING_COOKIE = "midimatches_seenbrowserwarning";
+export const DISABLED_MIDI_INPUTS_COOKIE = "midimatches_disabledmidiinputs";

--- a/assets/js/hooks/useAudioContextProvider.tsx
+++ b/assets/js/hooks/useAudioContextProvider.tsx
@@ -8,6 +8,7 @@ import {
   SOUND_VOLUME_COOKIE,
   MIN_SOUND_VOLUME,
   DEFAULT_SOUND_VOLUME,
+  DISABLED_MIDI_INPUTS_COOKIE,
 } from "../constants";
 import { useSamplePlayer, useWebMidi, useCookies } from ".";
 
@@ -20,9 +21,11 @@ export function useAudioContextProvider(): ToneAudioContextType {
   useEffect(() => {
     if (hasCookie(SOUND_VOLUME_COOKIE)) {
       const savedVolume = parseFloat(getCookie(SOUND_VOLUME_COOKIE));
-      const startingVolume =
-        savedVolume === MIN_SOUND_VOLUME ? DEFAULT_SOUND_VOLUME : savedVolume;
-      setCurrVolume(startingVolume);
+      setCurrVolume(savedVolume);
+    }
+    if (hasCookie(DISABLED_MIDI_INPUTS_COOKIE)) {
+      const savedDisabledMidiInputs = getCookie(DISABLED_MIDI_INPUTS_COOKIE);
+      setDisabledMidiInputIds(savedDisabledMidiInputs);
     }
   }, []);
 
@@ -40,9 +43,13 @@ export function useAudioContextProvider(): ToneAudioContextType {
   // midi inputs init
   const [originalMidiInputs, refreshMidiInputs] = useWebMidi();
   const [midiInputs, setMidiInputs] = useState<Array<Input>>([]);
-  const [disabledMidiInputIds, setDisabledMidiInputIds] = useState<
+  const [disabledMidiInputIds, _setDisabledMidiInputIds] = useState<
     Array<string>
   >([]);
+  const setDisabledMidiInputIds = (disabledIds: string[]) => {
+    setCookie(DISABLED_MIDI_INPUTS_COOKIE, disabledIds);
+    _setDisabledMidiInputIds(disabledIds);
+  };
   useEffect(() => {
     if (!!originalMidiInputs) {
       setMidiInputs(


### PR DESCRIPTION
- Keep track of disabled midi devices via cookie
- Allow for muted volume being stored in cookie