### PR TITLE
Bug Fixes: Player not Loaded + Unexpected Chat Event

### DIFF
--- a/assets/js/components/audio/PlaybackAudio.tsx
+++ b/assets/js/components/audio/PlaybackAudio.tsx
@@ -100,8 +100,10 @@ const PlaybackAudio: React.FC<PlaybackAudioProps> = ({
       samplePlayer.loop = false;
     }
 
-    samplePlayer.stop(`+0`);
-    samplePlayer.seek(0);
+    if (!!samplePlayer && samplePlayer.state === "started") {
+      samplePlayer.stop(`+0`);
+      samplePlayer.seek(0);
+    }
 
     samplePlayer.start(`+0.05`);
     part.start(`+0.05`);

--- a/lib/midimatches_web/channels/room_channel.ex
+++ b/lib/midimatches_web/channels/room_channel.ex
@@ -237,11 +237,14 @@ defmodule MidimatchesWeb.RoomChannel do
   @spec assign_game_server(%Phoenix.Socket{}) :: %Phoenix.Socket{}
   defp assign_game_server(%Phoenix.Socket{assigns: %{room_id: room_id}} = socket) do
     game_server = Pids.fetch({:game_server, room_id})
+    chat_server = Pids.fetch({:chat_server, room_id})
 
     if is_nil(game_server) do
       socket
     else
-      assign(socket, game_server: game_server)
+      socket
+      |> assign(game_server: game_server)
+      |> assign(chat_server: chat_server)
     end
   end
 end


### PR DESCRIPTION
- Ensure player is always loaded before trying to call stop
- Chat events after reconnect should go through with a reference to chat
server